### PR TITLE
Fix NPE in Maven when dependency directory does not exist

### DIFF
--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
@@ -175,7 +175,11 @@ public class DepCleanMojo extends AbstractMojo
         }
 
         /* Decompress dependencies */
-        JarUtils.decompressJars(project.getBuild().getDirectory() + "/" + "dependency");
+        String dependencyDirectoryName = project.getBuild().getDirectory() + "/" + "dependency";
+        File dependencyDirectory = new File(dependencyDirectoryName);
+        if (dependencyDirectory.exists()) {
+            JarUtils.decompressJars(dependencyDirectoryName);
+        }
 
         /* Analyze dependencies usage status */
         ProjectDependencyAnalysis projectDependencyAnalysis;


### PR DESCRIPTION
We had an NPE for an example app we tested DepClean against.
Kind regards
Wolfram