### PR TITLE
Fix Java 8 compatibility issue when building on Java9+ (https://github.com/castor-software/depclean/issues/25)

### DIFF
--- a/depclean-core/pom.xml
+++ b/depclean-core/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>se.kth.castor</groupId>
         <artifactId>depclean-parent-pom</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
     </parent>
 
     <!-- Coordinates -->
     <artifactId>depclean-core</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
 
     <name>depclean-core</name>
     <packaging>jar</packaging>

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -6,12 +6,12 @@
    <parent>
       <groupId>se.kth.castor</groupId>
       <artifactId>depclean-parent-pom</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.2-SNAPSHOT</version>
    </parent>
 
    <!-- Coordinates -->
    <artifactId>depclean-maven-plugin</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
 
    <packaging>maven-plugin</packaging>
    <name>depclean-maven-plugin</name>
@@ -78,7 +78,7 @@
       <dependency>
          <groupId>se.kth.castor</groupId>
          <artifactId>depclean-core</artifactId>
-          <version>1.1.1</version>
+          <version>1.1.2-SNAPSHOT</version>
       </dependency>
 
       <!-- Utils -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <!-- Coordinates -->
     <groupId>se.kth.castor</groupId>
     <artifactId>depclean-parent-pom</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <java.src.version>1.8</java.src.version>
         <java.test.version>1.8</java.test.version>
         <maven.javadoc.source>1.8</maven.javadoc.source>


### PR DESCRIPTION
#25 

Use `maven.compiler.release` to avoid runtime issue
As `maven.compiler.release` lead to the usage of `-release` `javac` option.
Removed `maven.compiler.source` and `maven.compiler.target` that are no longer useful.
Important: project cannot be build anymore with Java 8 because `javac` version 8 does not support `--release` option added by Maven property 
