### PR TITLE
Fix Java 8 compatibility issue

### DIFF
--- a/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
+++ b/depclean-maven-plugin/src/main/java/se/kth/depclean/DepCleanMojo.java
@@ -375,7 +375,7 @@ public class DepCleanMojo extends AbstractMojo {
     String projectJar = project.getArtifactId() + "-" + project.getVersion() + ".jar";
     long projectSize = FileUtils.sizeOf(new File(project.getBuild().getOutputDirectory()));
     sizeOfDependencies.put(projectJar, projectSize);
-    if (Files.exists(Path.of(
+    if (Files.exists(Paths.get(
         project.getBuild().getDirectory() + File.separator + DIRECTORY_TO_COPY_DEPENDENCIES))) {
       Iterator<File> iterator = FileUtils.iterateFiles(
           new File(

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.javadoc.source>11</maven.javadoc.source>
+    <maven.compiler.release>8</maven.compiler.release>
+    <maven.javadoc.source>8</maven.javadoc.source>
     <maven.maven-javadoc-plugin.version>3.2.0</maven.maven-javadoc-plugin.version>
     <maven.jacoco.plugin.version>0.8.6</maven.jacoco.plugin.version>
     <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>


### PR DESCRIPTION
- Update the pom.xml to build a version compatible with Java 8 using AdoptopenJDK 11.
- `maven.compiler.release` (`javac` option `--release`) is used instead of `maven.compiler.source` and `maven.compiler.target` (`javac` options `-source` and `-target`) to produce class files link against the appropriate platform version (see http://openjdk.java.net/jeps/247).