### PR TITLE
Fix JarUtilsTest

### DIFF
--- a/depclean-maven-plugin/src/test/java/se/kth/depclean/util/JarUtilsTest.java
+++ b/depclean-maven-plugin/src/test/java/se/kth/depclean/util/JarUtilsTest.java
@@ -32,10 +32,10 @@ class JarUtilsTest {
     try {
       // make a copy of the directory containing the JAR files
       FileUtils.copyDirectory(
-          originalDir,
-          copyDir
+          originalDir,    // If directory is empty/Null then NPE will be thrown.
+          copyDir         // If directory is empty/Null then NPE will be thrown.
       );
-    } catch (IOException e) {
+    } catch (IOException | NullPointerException e) {
       log.error("Error copying the directory: src/test/resources/JarUtilsResources");
     }
   }
@@ -56,7 +56,7 @@ class JarUtilsTest {
     if (jcabiSSHJar.exists() && jcabiXMLJar.exists()) {
       decompress();
       assertFalse(FileUtils.directoryContains(copyDir, jcabiSSHJar));
-      assertFalse(FileUtils.directoryContains(copyDir, jcabiSSHJar));
+      assertFalse(FileUtils.directoryContains(copyDir, jcabiXMLJar));
     }
 
   }


### PR DESCRIPTION
There was a typing mistake in JarUtilsTest.java more precisely in method "whenDecompressJarFiles_thenJarFilesAreRemoved()" and also added NullPointerExcption in case the directory is null.