### PR TITLE
Fix wrong report generated when running `mvn checkstyle:checkstyle`

### DIFF
--- a/depclean-core/pom.xml
+++ b/depclean-core/pom.xml
@@ -20,6 +20,7 @@
 
   <properties>
     <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <checkstyle.config.location>../checkstyle.xml</checkstyle.config.location>
     <linkXRef>false</linkXRef>
   </properties>
 

--- a/depclean-maven-plugin/pom.xml
+++ b/depclean-maven-plugin/pom.xml
@@ -17,6 +17,7 @@
 
   <properties>
     <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <checkstyle.config.location>../checkstyle.xml</checkstyle.config.location>
     <linkXRef>false</linkXRef>
   </properties>
 


### PR DESCRIPTION
See https://github.com/castor-software/depclean/issues/70